### PR TITLE
Fix hero section overlap

### DIFF
--- a/app/components/hero.tsx
+++ b/app/components/hero.tsx
@@ -9,7 +9,7 @@ export function Hero() {
     <Container className="text-white text-left pb-64">
       <Title
         order={1}
-        className="text-5xl h-28 max-w-[25rem] font-bold pb-8 whitespace-pre-line"
+        className="text-5xl min-h-28 max-w-[25rem] font-bold pb-8 whitespace-pre-line"
       >
         {fin ? (
           "Konsulenter som ikke koster skjorta."


### PR DESCRIPTION
Fikset at komponenten av og til kan overskrive brødteksten under, ved sette høyden til minimum 28 slik at den kan bli høyere dersom den har dårlig plass.